### PR TITLE
only checkMessageMemberCustomizable when enabled

### DIFF
--- a/src/NotificationCenter/Util/MemberCustomizableHelper.php
+++ b/src/NotificationCenter/Util/MemberCustomizableHelper.php
@@ -70,6 +70,10 @@ SQL
      */
     public function checkMessageMemberCustomizable($value, $dc)
     {
+        if (!$value) {
+            return $value;
+        }
+        
         /** @noinspection PhpUndefinedMethodInspection */
         $notification     = Notification::findByPk($dc->activeRecord->pid);
         $notificationType = Notification::findGroupForType($notification->type);


### PR DESCRIPTION
When saving a notification I get the following error:

![screenshot](https://user-images.githubusercontent.com/4970961/63522424-37456280-c4f0-11e9-994a-8577023b801f.png)

Surely this check should only be done, if the option is actually enabled?