### PR TITLE
only checkMessageMemberCustomizable when enabled

### DIFF
--- a/src/Util/MemberCustomizableHelper.php
+++ b/src/Util/MemberCustomizableHelper.php
@@ -84,6 +84,10 @@ class MemberCustomizableHelper
      */
     public function checkMessageMemberCustomizable($value, $dc)
     {
+        if (!$value) {
+            return $value;
+        }
+
         /** @noinspection PhpUndefinedMethodInspection */
         $notification     = Notification::findByPk($dc->activeRecord->pid);
         $notificationType = Notification::findGroupForType($notification->type);


### PR DESCRIPTION
When saving a notification I get the following error:

![screenshot](https://user-images.githubusercontent.com/4970961/63532112-dc1c6b80-c501-11e9-8860-f13d7fae7906.png)

Surely this check should only be done, if the option is actually enabled?